### PR TITLE
Add configurable queue monitoring

### DIFF
--- a/Application.cpp
+++ b/Application.cpp
@@ -63,6 +63,7 @@ bool Application::initialize() {
         // Create thread pool
         int threadCount = config.threadCount > 0 ? config.threadCount : std::thread::hardware_concurrency();
         pool = new ThreadPool(threadCount);
+        pool->setMaxQueueSize(static_cast<size_t>(config.maxQueueSize));
 
         // Create necessary directories
         createDirectories();
@@ -236,6 +237,7 @@ void Application::configureSettings() {
         std::cout << "│ 9. Thread Count: " << std::setw(29) << (config.threadCount == 0 ? "Auto" : std::to_string(config.threadCount)) << " │\n";
         std::cout << "│ 10. Archive Processed Files: " << std::setw(18) << (config.archiveProcessedFiles ? "Yes" : "No") << " │\n";
         std::cout << "│ 11. Move Error Files: " << std::setw(25) << (config.moveErrorFiles ? "Yes" : "No") << " │\n";
+        std::cout << "│ 12. Max Queue Size: " << std::setw(26) << config.maxQueueSize << " │\n";
         std::cout << "│ 0. Return to Main Menu                        │\n";
         std::cout << "└───────────────────────────────────────────────┘\n";
 
@@ -304,6 +306,14 @@ void Application::configureSettings() {
                     std::string answer;
                     std::getline(std::cin, answer);
                     config.moveErrorFiles = (std::tolower(answer[0]) == 'y');
+                    break;
+                }
+                case 12: {
+                    std::cout << "Enter maximum queue size (0 for unlimited): ";
+                    std::string sizeStr;
+                    std::getline(std::cin, sizeStr);
+                    config.maxQueueSize = std::stoi(sizeStr);
+                    pool->setMaxQueueSize(static_cast<size_t>(config.maxQueueSize));
                     break;
                 }
                 default:
@@ -391,6 +401,15 @@ void Application::processFile(const std::string& filepath) {
         // Remove the file from active files
         this->stats.removeActiveFile(filepath);
     };
+
+    // Wait if the queue is above the configured limit
+    if (config.maxQueueSize > 0) {
+        while (pool->getQueueSize() >= static_cast<size_t>(config.maxQueueSize)) {
+            std::cout << "⚠️  ThreadPool queue full (" << pool->getQueueSize()
+                      << "/" << config.maxQueueSize << "). Waiting..." << std::endl;
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+    }
 
     // Enqueue the task in the thread pool
     pool->enqueue(processFunction);

--- a/Application.h
+++ b/Application.h
@@ -36,6 +36,7 @@ struct AppConfig {
     std::string errorFolder = "error_files";
     int batchSize = 1000;
     int threadCount = 0; // 0 means use hardware concurrency
+    int maxQueueSize = 20; // Maximum tasks waiting in the pool (0 for unlimited)
     bool archiveProcessedFiles = false;
     bool moveErrorFiles = true;
 };

--- a/FileWatcher.cpp
+++ b/FileWatcher.cpp
@@ -28,6 +28,15 @@ void watch_directory(const std::string& dir_path, ThreadPool& pool,
                 std::string filepath = entry.path().string();
                 if (seen.find(filepath) == seen.end()) {
                     seen.insert(filepath);
+                    // Wait if queue is full
+                    if (pool.getMaxQueueSize() > 0) {
+                        while (pool.getQueueSize() >= pool.getMaxQueueSize()) {
+                            std::cout << "⚠️  ThreadPool queue full (" << pool.getQueueSize()
+                                      << "/" << pool.getMaxQueueSize() << "). Waiting..." << std::endl;
+                            std::this_thread::sleep_for(std::chrono::seconds(1));
+                        }
+                    }
+
                     pool.enqueue([filepath, pigs_collection, posture_collection]() {
                         // Using default values for stats and batchSize
                         parse_and_batch_insert(filepath, pigs_collection, posture_collection, nullptr, 1000);

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A robust CSV parser designed to process and store pig posture data in MongoDB. T
 - Automatic pig registration in the database
 - Batch processing for efficient database operations
 - Error handling and reporting
+- Configurable thread pool queue limit to avoid overwhelming the system
 
 ## Prerequisites
 

--- a/ThreadPool.cpp
+++ b/ThreadPool.cpp
@@ -25,10 +25,26 @@ ThreadPool::ThreadPool(size_t num_threads) : stop(false) {
 
 void ThreadPool::enqueue(std::function<void()> task) {
     {
-        std::lock_guard lock(queue_mutex);
-        tasks.emplace(task);
+        std::unique_lock lock(queue_mutex);
+        if (max_queue_size > 0) {
+            condition.wait(lock, [this] {
+                return tasks.size() < max_queue_size || stop;
+            });
+        }
+        tasks.emplace(std::move(task));
     }
     condition.notify_one();
+}
+
+size_t ThreadPool::getQueueSize() {
+    std::lock_guard lock(queue_mutex);
+    return tasks.size();
+}
+
+void ThreadPool::setMaxQueueSize(size_t size) {
+    std::lock_guard lock(queue_mutex);
+    max_queue_size = size;
+    condition.notify_all();
 }
 
 ThreadPool::~ThreadPool() {

--- a/ThreadPool.h
+++ b/ThreadPool.h
@@ -11,11 +11,16 @@ class ThreadPool {
 public:
     ThreadPool(size_t num_threads);
     void enqueue(std::function<void()> task);
+    size_t getQueueSize();
+    void setMaxQueueSize(size_t size);
+    size_t getMaxQueueSize() const { return max_queue_size; }
     ~ThreadPool();
 
 private:
     std::vector<std::thread> workers;
     std::queue<std::function<void()>> tasks;
+
+    size_t max_queue_size{0};
 
     std::mutex queue_mutex;
     std::condition_variable condition;


### PR DESCRIPTION
## Summary
- allow configuring maximum threadpool queue size
- block enqueuing when the pool queue is full
- support changing queue limit in settings
- document queue limit option

## Testing
- `./run.sh` *(fails: libmongocxx missing)*
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68558d78003c83248c268b69f83bb351