### PR TITLE
Optimize batch insertion allocation

### DIFF
--- a/CSVIngest.cpp
+++ b/CSVIngest.cpp
@@ -70,6 +70,7 @@ void parse_and_batch_insert(const std::string& filepath,
     std::unordered_set<int> checked_pigs;
     std::vector<bsoncxx::document::value> batch;
     const size_t BATCH_SIZE = batchSize > 0 ? batchSize : 1000;
+    batch.reserve(BATCH_SIZE);
 
     // Track statistics
     int recordsInserted = 0;


### PR DESCRIPTION
## Summary
- preallocate posture insertion batch

## Testing
- `bash run.sh` *(fails: libmongocxx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68558d6b495883248a0b3b853fa01be2