### PR TITLE
Remove unused pig helper functions

### DIFF
--- a/CSVIngest.cpp
+++ b/CSVIngest.cpp
@@ -14,26 +14,6 @@
 using bsoncxx::builder::stream::document;
 using bsoncxx::builder::stream::finalize;
 
-bool pig_exists(int pig_id, mongocxx::collection& pigs_collection) {
-    auto result = pigs_collection.find_one(document{} << "pigId" << pig_id << finalize);
-    return result ? true : false;
-}
-
-void insert_pig_if_needed(int pig_id, mongocxx::collection& pigs_collection) {
-    if (!pig_exists(pig_id, pigs_collection)) {
-        Pig new_pig(
-            pig_id,
-            "UNKNOWN_TAG",
-            "UNKNOWN_BREED",
-            0,
-            CurrentLocation("UNKNOWN_FARM", "UNKNOWN_BARN", "UNKNOWN_STALL")
-        );
-
-        pigs_collection.insert_one(new_pig.to_bson().view());
-        std::cout << "[🐖 New Pig Registered] Pig ID: " << pig_id << std::endl;
-    }
-}
-
 void parse_and_batch_insert(const std::string& filepath,
     mongocxx::collection pigs_collection,
     mongocxx::collection posture_collection,


### PR DESCRIPTION
## Summary
- remove `pig_exists` and `insert_pig_if_needed` from `CSVIngest.cpp`

## Testing
- `./run.sh` *(fails: libmongocxx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68558d0a013083249f84b6db6f98c2f2